### PR TITLE
Improve nodejs install

### DIFF
--- a/tasks/install.bin.yml
+++ b/tasks/install.bin.yml
@@ -30,6 +30,12 @@
     - node
     - npm
 
+- name: Prepare link so both node and nodejs are acceptable executable name.
+  file:
+    state=link
+    src=/usr/bin/node
+    dest=/usr/bin/nodejs
+
 # - name: Ensure proper PATH for nodejs
 #   lineinfile:
 #     line={{ item }}


### PR DESCRIPTION
- Prepare link so both `node` and `nodejs` are acceptable executable name.
